### PR TITLE
fix: 'enteries' to 'entries' typo

### DIFF
--- a/schemas/objects/techCategory.ts
+++ b/schemas/objects/techCategory.ts
@@ -12,9 +12,9 @@ export default {
     {
       type: 'array',
       title: 'Entries',
-      name: 'enteries',
+      name: 'entries',
       description: 'Insert whatever you need here',
-      of: [{type: 'string'}],
+      of: [{ type: 'string' }],
     },
   ],
 }


### PR DESCRIPTION
Fix typo in TechCategory schema type.