### PR TITLE
55: translations of the Sanity-field-labels

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,14 +1,14 @@
-import {defineConfig, Rule} from 'sanity'
-import {deskTool} from 'sanity/desk'
-import {visionTool} from '@sanity/vision'
-import {schemaTypes} from './schemas'
-import {documentI18n} from '@sanity/document-internationalization'
-import {Ti18nConfig} from '@sanity/document-internationalization/src/types'
-import {deskStructure} from './deskStructure'
+import { defineConfig, Rule } from 'sanity'
+import { deskTool } from 'sanity/desk'
+import { visionTool } from '@sanity/vision'
+import { schemaTypes } from './schemas'
+import { documentI18n } from '@sanity/document-internationalization'
+import { Ti18nConfig } from '@sanity/document-internationalization/src/types'
+import { deskStructure } from './deskStructure'
 
 export const supportedLanguages = [
-  {id: 'en', title: 'English', },
-  {id: 'no', title: 'Norwegian', isDefault: true},
+  { id: 'en', title: 'English', longTitle: 'Engelsk (English)', },
+  { id: 'no', title: 'Norwegian', longTitle: 'Norsk (Norwegian)', isDefault: true },
 ]
 supportedLanguages.find(l => l.isDefault)
 const i18nConfig: Ti18nConfig = {
@@ -24,13 +24,13 @@ const localeString = {
   // making it stand out as the main field.
   fieldsets: [
     {
-      title: 'Translations',
+      title: 'Oversettelser (Translations)',
       name: 'translations'
     }
   ],
   // Dynamically define one field per language
   fields: supportedLanguages.map(lang => ({
-    title: lang.title,
+    title: lang.longTitle,
     name: lang.id,
     type: 'string',
     fieldset: lang.isDefault ? null : 'translations',
@@ -47,16 +47,16 @@ const localeBlock = {
   // making it stand out as the main field.
   fieldsets: [
     {
-      title: 'Translations',
+      title: 'Oversettelser (Translations)',
       name: 'translations'
     }
   ],
   // Dynamically define one field per language
   fields: supportedLanguages.map(lang => ({
-    title: lang.title,
+    title: lang.longTitle,
     name: lang.id,
     type: 'array',
-    of: [{type: 'block'}, {type: 'localeImage'}],
+    of: [{ type: 'block' }, { type: 'localeImage' }],
     fieldset: lang.isDefault ? null : 'translations',
     validation: (rule: Rule) => rule.required()
   }))
@@ -66,31 +66,34 @@ const localeImage = {
   title: "Localized Image",
   name: 'localeImage',
   type: 'object',
-  fields:[ {
+  fields: [{
     title: 'image',
     name: 'Image',
     type: 'image',
-  },{
+  }, {
+    title: 'Alternativ Tekst (Alt Text)',
     type: "string",
     name: "altText",
-    description: "Accessabillity text describing the image"
+    description: "Accessabillity text describing the image in case the image is missing or doesn't render"
   },
-{type: 'string',
-description: 'Adding a url here will transform the entire image into a clickable link. If linking internally (at hulen.no), you only need to add f.ex "/contactUs". If linking externally, you need the full https://google.com type link',
-name: "linkUrl",
-}]
+  {
+    type: 'string',
+    description: 'Adding a url here will transform the entire image into a clickable link. If linking internally (at hulen.no), you only need to add f.ex "/contactUs". If linking externally, you need the full https://google.com type link',
+    name: "linkUrl",
+  }]
 
 }
 
 const imageWithLocaleAlt = {
-    type: 'image',
-    name: 'imageWithLocaleAlt',
-    title: 'Image',
-    fields: [{
-      name: "altText",
-      type: "localeString",
-      description: "Accessibility text describing the image"
-    }]
+  type: 'image',
+  name: 'imageWithLocaleAlt',
+  title: 'Bilde (Image)',
+  fields: [{
+    title: 'Alternativ Tekst (Alt Text)',
+    name: "altText",
+    type: "localeString",
+    description: "Accessabillity text describing the image in case the image is missing or doesn't render"
+  }]
 }
 
 
@@ -103,11 +106,11 @@ export default defineConfig({
 
   plugins: [deskTool(
     {
-      structure: (S, {schema}) => deskStructure(i18nConfig, S, schema)
+      structure: (S, { schema }) => deskStructure(i18nConfig, S, schema)
     }
   ), visionTool(), documentI18n(i18nConfig)],
 
   schema: {
-    types: [localeString,localeBlock,localeImage, imageWithLocaleAlt, ...schemaTypes]
+    types: [localeString, localeBlock, localeImage, imageWithLocaleAlt, ...schemaTypes]
   }
 })

--- a/schemas/api/contactFormApi.ts
+++ b/schemas/api/contactFormApi.ts
@@ -2,7 +2,7 @@ import { Rule } from 'sanity'
 
 export default {
   type: 'document',
-  title: 'Join Email Form Api',
+  title: 'Bli Med Skjema for Api (Join Us Form for Api)',
   name: 'joinEmailFormApi',
   fields: [
     {

--- a/schemas/contactPage/contactPage.ts
+++ b/schemas/contactPage/contactPage.ts
@@ -1,8 +1,8 @@
-import {Rule} from 'sanity'
+import { Rule } from 'sanity'
 
 //This is the schema for the contact page. There is only this, so we bundle everything into it
 export default {
-  title: 'Contact Info',
+  title: 'Kontakt Oss (Contacts)',
   name: 'contactPage',
   type: 'document',
   description: 'Contact page information. Only the newest published version will be available',
@@ -14,7 +14,7 @@ export default {
     },
     {
       type: 'localeBlock',
-      title: 'headerInfo',
+      title: 'Toppinfo (Header Info)',
       name: 'headerInfoBlock',
       validation: (rule: Rule) => rule.required(),
     },
@@ -31,17 +31,17 @@ export default {
         {
           type: 'string',
           name: 'email',
-          title: 'Email',
+          title: 'Epost (Email)',
         },
       ],
     },
     {
       type: 'array',
-      title: 'Contact Info',
+      title: 'Kontaktinfo (Contact Info)',
       name: 'contactList',
-      of: [{type: 'contactInfo'}],
+      of: [{ type: 'contactInfo' }],
       options: {
-        modal: {type: 'dialog', width: '80%'}, //Makes the modal type a popover
+        modal: { type: 'dialog', width: '80%' }, //Makes the modal type a popover
       },
     },
   ],

--- a/schemas/footer/footer.ts
+++ b/schemas/footer/footer.ts
@@ -10,22 +10,22 @@ export default {
     fields: [
         {
             type: "string",
-            title: "Title",
+            title: "Tittel (Title)",
             name: "title",
         },
         {
             type: "number",
-            title: "Sort Order",
+            title: "Sorteringsrekkefølge (Sort Order)",
             name: "sortOrder",
             description: "Sort order defines, in increasing order the placement of each element from the left",
             validation: (rule: Rule) => rule.required().custom(validateUniquenessNumber)
 
         },
-       {
-           type: "localeBlock",
-           title: "Footer element",
-           name: "footerElement",
-           validation: (rule: Rule) => rule.required(),
-       }
+        {
+            type: "localeBlock",
+            title: "Bunnelement (Footer element)",
+            name: "footerElement",
+            validation: (rule: Rule) => rule.required(),
+        }
     ]
-   }
+}

--- a/schemas/guardianInfo/guardianInfo.ts
+++ b/schemas/guardianInfo/guardianInfo.ts
@@ -1,7 +1,7 @@
 export default {
   type: 'document',
   name: 'guardianInfo',
-  title: 'Guardian Info',
+  title: 'Verge (Guardian)',
   fields: [
     {
       type: 'string',
@@ -11,27 +11,27 @@ export default {
     }, {
       type: 'localeString',
       name: 'header',
-      title: 'Page header',
+      title: 'Tittel (Page header)',
       description: 'The big bold letters at the top',
     }, {
       type: 'localeBlock',
       name: 'intro',
-      title: 'Introduction text',
+      title: 'Introtekst (Intro Text)',
       description: 'The text below the big bold letters at the top'
     }, {
       type: 'localeString',
       name: 'subHeading',
-      title: "Subheading",
+      title: "Undertittel (Subheader)",
       description: 'The subheading beside the image'
     }, {
       type: 'localeBlock',
       name: 'description',
-      title: 'Description',
+      title: 'Beskrivelse (Description)',
       description: 'The text below the subheading and beside the image'
     }, {
       type: 'imageWithLocaleAlt',
       name: 'guardianImage',
-      title: 'Image',
+      title: 'Bilde (Image)',
       description: 'The image beside the text',
     }
   ],

--- a/schemas/joinUsPage/benefitsSection.ts
+++ b/schemas/joinUsPage/benefitsSection.ts
@@ -1,13 +1,14 @@
-import {Rule} from 'sanity'
+import { Rule } from 'sanity'
 
 export default {
-  title: 'Benefits section',
+  title: 'Fordeler (Benefits)',
   type: 'object',
   name: 'benefitsSection',
   description: 'List out the benefits of Hulen here',
   fields: [
-    {title: 'Header', name: 'header', type: 'localeString', validation: (rule: Rule) => rule.required()},
+    { title: 'Tittel (Header)', name: 'header', type: 'localeString', validation: (rule: Rule) => rule.required() },
     {
+      title: 'Ikon (Icon)',
       type: 'image',
       image: 'icon',
       name: 'descImage',
@@ -16,7 +17,7 @@ export default {
     {
       type: 'localeBlock',
       name: 'content',
-      title: 'Content',
+      title: 'Innhold (Content)',
       validation: (rule: Rule) => rule.required(),
     },
   ],

--- a/schemas/joinUsPage/joinEmailForm.ts
+++ b/schemas/joinUsPage/joinEmailForm.ts
@@ -2,38 +2,44 @@ import { Rule } from 'sanity'
 
 export default {
   type: 'object',
-  title: 'Join email form',
+  title: 'Bli Med Epostskjema (Join Us email form)',
   name: 'joinEmailForm',
   fields: [
     {
       type: 'localeString',
       name: 'emailFormTitle',
+      title: 'Skjematittel (Form Title)',
       validation: (rule: Rule) => rule.required(),
     },
     {
       type: 'localeString',
       name: 'emailFormLabel',
+      title: 'Epostetikett (Email Label)',
       validation: (rule: Rule) => rule.required(),
 
     },
     {
       type: 'localeString',
       name: 'nameFormLabel',
+      title: 'Navnetikett (Name Label)',
       validation: (rule: Rule) => rule.required(),
     },
     {
       type: 'localeString',
       name: 'ageFormLabel',
+      title: 'Aldersetikett (Age Label)',
       validation: (rule: Rule) => rule.required(),
     },
     {
       type: 'localeString',
       name: 'jobFormLabel',
+      title: 'Stillingsetikett (Position Label)',
       validation: (rule: Rule) => rule.required(),
     },
     {
       type: 'localeString',
       name: 'relevantInfoFormLabel',
+      title: 'Relevant-info-etikett (Relevant Info Label)',
       validation: (rule: Rule) => rule.required(),
     },
   ],

--- a/schemas/joinUsPage/joinSection.ts
+++ b/schemas/joinUsPage/joinSection.ts
@@ -1,12 +1,12 @@
-import {Rule} from 'sanity'
+import { Rule } from 'sanity'
 
 export default {
-  title: 'Join us section',
+  title: 'Bli Med (Join! section)',
   type: 'object',
   name: 'joinUsSection',
   fields: [
     {
-      title: 'Header',
+      title: 'Tittel (Header)',
       name: 'header',
       type: 'localeString',
       validation: (rule: Rule) => rule.required(),
@@ -14,24 +14,24 @@ export default {
     {
       type: 'image',
       name: 'icon',
-      title: 'Icon',
+      title: 'Ikon (Icon)',
       description: 'The icon to display. Please only upload svg icons here',
     },
     {
       type: 'localeBlock',
       name: 'content',
-      title: 'Content',
+      title: 'Innhold (Content)',
       validation: (rule: Rule) => rule.required(),
     },
     {
       type: 'localeString',
       name: 'emailPreface',
-      title: 'Preface before email',
+      title: 'Epost-Forord (Preface Email)',
       description: 'Preface before email. Excluded from locale text',
       validation: (rule: Rule) => rule.required(),
     },
     {
-      title: 'Contact adress',
+      title: 'Konaktaddresse (Contact Address)',
       name: 'email',
       type: 'string',
       description: 'Contact adress. Only put in the mail here',

--- a/schemas/joinUsPage/joinUsPage.ts
+++ b/schemas/joinUsPage/joinUsPage.ts
@@ -1,7 +1,7 @@
 import { Rule } from 'sanity'
 
 export default {
-  title: 'Join Us',
+  title: 'Bli Frivillig (Join Us)',
   name: 'joinUsPage',
   type: 'document',
   fields: [
@@ -9,12 +9,12 @@ export default {
       type: 'string',
       name: 'title',
       title: 'title',
-      description: 'title of object, for storage purposes only',
+      description: 'title of object, for storage purposes onsly',
     },
     {
       type: 'localeString',
       name: 'pageTitle',
-      title: 'Page Header',
+      title: 'Tittel (Page Header)',
       description: 'This is the top header of the page',
       validation: (rule: Rule) => rule.required(),
     },
@@ -26,7 +26,7 @@ export default {
       validation: (rule: Rule) => rule.required(),
     },
     {
-      title: 'Navigation Buttons',
+      title: 'Navigeringsknapper (Navigation Buttons)',
       name: 'navigationButtons',
       description: 'Clickable navigation button, be careful when touching these',
       type: 'array',
@@ -35,18 +35,18 @@ export default {
     {
       type: 'joinUsSection',
       name: 'joinSection',
-      title: 'Join Section',
+      title: 'Bli Med! (Join! section)',
       validation: (rule: Rule) => rule.required(),
     },
     {
-      title: 'positionDescription',
+      title: 'Stillings-Forord (Position preface)',
       type: 'positionPreface',
       description: 'Info text before positions are listed',
       name: 'positionPreface',
     },
     {
       type: 'array',
-      title: 'Available Positions',
+      title: 'Stillinger (Positions)',
       description: 'Each available position',
       name: 'positions',
       of: [{ type: 'positionEl' }],
@@ -54,13 +54,13 @@ export default {
     {
       type: 'benefitsSection',
       name: 'benefitsSection',
-      title: 'Benefits Section',
+      title: 'Fordeler (Benefits)',
       validation: (rule: Rule) => rule.required(),
     },
     {
       type: 'joinEmailForm',
       name: 'joinEmailForm',
-      title: 'Join Us Email Form',
+      title: 'Epostskjema (Email Form)',
       description: 'Email form to apply for positions at Hulen',
       validation: (rule: Rule) => rule.required(),
     },

--- a/schemas/joinUsPage/positionButtons.ts
+++ b/schemas/joinUsPage/positionButtons.ts
@@ -1,5 +1,5 @@
 export default {
-  title: 'Navigation button',
+  title: 'Navigeringsknapp (Navigation button)',
   name: 'joinUsNavButton',
   type: 'object',
   fields: [
@@ -10,7 +10,7 @@ export default {
       title: 'Button Label',
     },
     {
-      title: 'Section Url',
+      title: 'Seksjons-Url (Section Url)',
       type: 'string',
       name: 'section',
       description:

--- a/schemas/joinUsPage/positionDescriptionSection.ts
+++ b/schemas/joinUsPage/positionDescriptionSection.ts
@@ -1,13 +1,13 @@
 import { Rule } from 'sanity'
 
 export default {
-  title: 'Position Description section',
+  title: 'Stillings-Forord (Position preface)',
   type: 'object',
   name: 'positionPreface',
   description: 'Introduction before positions',
   fields: [
     {
-      title: 'Header',
+      title: 'Tittel (Header)',
       name: 'header',
       type: 'localeString',
       validation: (rule: Rule) => rule.required(),
@@ -15,10 +15,11 @@ export default {
     {
       type: 'localeBlock',
       name: 'content',
-      title: 'Content',
+      title: 'Innhold (Content)',
       validation: (rule: Rule) => rule.required(),
     },
     {
+      title: 'Bilde (Image)',
       type: 'image',
       image: 'icon',
       name: 'descImage',

--- a/schemas/joinUsPage/positionEl.ts
+++ b/schemas/joinUsPage/positionEl.ts
@@ -1,11 +1,12 @@
 import { Rule } from 'sanity'
 
 export default {
-  title: 'Position',
+  title: 'Stilling (Position)',
   name: 'positionEl',
   type: 'object',
   fields: [
     {
+      title: 'Tittel (Title)',
       type: 'localeString',
       name: 'title',
       description:
@@ -13,7 +14,7 @@ export default {
       validation: (rule: Rule) => rule.required(),
     },
     {
-      title: 'Category',
+      title: 'Katgori (Category)',
       name: 'category',
       type: 'string',
       description: 'Which category to put the position in, either night shift or normal shift',
@@ -29,13 +30,13 @@ export default {
       type: 'localeBlock',
       desciption: 'Description of a position. Feel free to pour your heart out',
       name: 'description',
-      title: 'Description',
+      title: 'Beskrivelse (Description)',
       validation: (rule: Rule) => rule.required(),
     },
     {
       type: 'imageWithLocaleAlt',
       name: 'descImage',
-      title: 'Decorative Image',
+      title: 'Stillingsbilde (Decorative Image)',
       description:
         'While you can put an image into the above description, it is easier controlled to put it here',
     },

--- a/schemas/navigation/navBar.ts
+++ b/schemas/navigation/navBar.ts
@@ -1,16 +1,17 @@
 export default {
-  title: 'Navigation bar',
+  title: 'Navigeringsmeny (Navigation Bar)',
   name: 'navBarProps',
   type: 'document',
   fields: [
     {
       type: 'string',
       name: 'version',
-      title: 'Version title',
+      title: 'Versjontittel (Version title)',
       description:
         'You only need one navbar. Hulen.no will pick the latest navbar, so you can work on creating a new one, or edit the current one. Version title is a descriptive field only.',
     },
     {
+      title: 'Navigeringsmenylogo (Navbar Logo)',
       type: 'imageWithLocaleAlt',
       name: 'navbarLogo',
       description:
@@ -18,7 +19,7 @@ export default {
     },
     {
       type: 'array',
-      title: 'Navigation Buttons',
+      title: 'Navigeringsknapper (Navigation Buttons)',
       name: 'navElements',
       of: [{ type: 'navElement' }],
     },

--- a/schemas/navigation/navElement.ts
+++ b/schemas/navigation/navElement.ts
@@ -1,7 +1,7 @@
-import {Rule} from 'sanity'
+import { Rule } from 'sanity'
 
 export default {
-  title: 'Navigation Button Element',
+  title: 'Navigeringsknapp (Navigation Button)',
   name: 'navElement',
   type: 'object',
   fields: [
@@ -14,7 +14,7 @@ export default {
     {
       type: 'string',
       name: 'subUrl',
-      title: 'Url Path',
+      title: 'Url-sti (Url Path)',
       description:
         "the relative path to this button navigates to. Relative here means that for 'hulen/people', just add 'people' as value. For further chaining, add 'people/somePerson'.",
       validation: (rule: Rule) => rule.required(),
@@ -22,10 +22,10 @@ export default {
     {
       type: 'array',
       name: 'subNavElements',
-      title: 'Dropdown Links',
+      title: 'Rullegardinsmeny (Dropdown List)',
       description:
         'Navigation elements that should be present in a dropdown menu under the current element. Note that we only support one level of dropdown elements.',
-      of: [{type: 'navElement'}],
+      of: [{ type: 'navElement' }],
     },
   ],
 }

--- a/schemas/notFound/notFound.ts
+++ b/schemas/notFound/notFound.ts
@@ -1,11 +1,12 @@
 export default {
-  title: 'Page Not found',
+  title: 'Side Ikke Funnet (Page Not found)',
   name: 'notFoundPage',
   type: 'document',
   description:
     'Information display when page is not found. Only the latest updated document will be used',
   fields: [
     {
+      title: 'Ikke Funnet Bilde (Not Found Image)',
       type: 'imageWithLocaleAlt',
       name: 'notFoundImage',
       description: 'The image that appears when not found',
@@ -13,13 +14,13 @@ export default {
 
     {
       type: 'localeString',
-      title: 'Info Text',
+      title: 'Info Tekst (Info Text)',
       name: 'infotext',
       description: 'The information text provided if the page is not found',
     },
     {
       type: 'localeString',
-      title: 'Back button label',
+      title: 'Tilbakeknappstittel (Back Button Label)',
       name: 'backbuttonlabel',
       description: 'The label of the back button',
     },

--- a/schemas/objects/dictionaryContactInfo.ts
+++ b/schemas/objects/dictionaryContactInfo.ts
@@ -1,25 +1,25 @@
 export default {
   type: 'object',
-  title: 'Contact info',
+  title: 'Kontaktinformasjon (Contact info)',
   name: 'contactInfo',
   fields: [
     {
-      title: 'title',
+      title: 'Tittel (Title)',
       name: 'title',
       type: 'localeString',
     },
     {
-      title: 'name',
+      title: 'Navn (Name)',
       name: 'name',
       type: 'string',
     },
     {
       type: 'string',
       name: 'email',
-      title: 'email',
+      title: 'Epost (email)',
     },
     {
-      title: 'phone',
+      title: 'Telefon (Phone)',
       name: 'phone',
       type: 'string',
     },

--- a/schemas/objects/positionType.ts
+++ b/schemas/objects/positionType.ts
@@ -4,22 +4,22 @@ export default {
   name: 'positionType',
   fields: [
     {
-      title: 'title',
+      title: 'Tittel (Title)',
       name: 'title',
       type: 'string',
     },
     {
-      title: 'key',
+      title: 'Nøkkel (Key)',
       name: 'key',
       type: 'string',
     },
     {
       type: 'string',
       name: 'en',
-      title: 'en',
+      title: 'Engelsk (English)',
     },
     {
-      title: 'no',
+      title: 'Norsk (Norwegian)',
       name: 'no',
       type: 'string',
     },

--- a/schemas/objects/techCategory.ts
+++ b/schemas/objects/techCategory.ts
@@ -1,17 +1,17 @@
 export default {
-  title: 'Tech Category',
+  title: 'Tech Kategori (Tech Category)',
   name: 'techCategory',
   type: 'object',
   fields: [
     {
       type: 'string',
-      title: 'Category',
+      title: 'Kategori (Category)',
       name: 'category',
       description: 'For grouping equipment, name your category here. ',
     },
     {
       type: 'array',
-      title: 'Entries',
+      title: 'Oppføringer (Entries)',
       name: 'entries',
       description: 'Insert whatever you need here',
       of: [{ type: 'string' }],

--- a/schemas/pages/pageContent.ts
+++ b/schemas/pages/pageContent.ts
@@ -1,22 +1,23 @@
 
 
 export default {
-    title: 'Page',
+    title: 'Side (Page)',
     name: 'pageProps',
     type: 'document',
     fields: [
         {
-            type: "string", 
-            name: "title", 
-            title: "Page Name",
+            type: "string",
+            name: "title",
+            title: "Sidetittel (Page Name)",
             description: "This field is used to match Hulen.No page routing and need to match exactly the page config"
-            },
+        },
         {
-        description: "The content you wish to show",
-        type: 'localeBlock',
-        name: "locale",
-   
-    }]
+            title: 'Innhold (Content)',
+            description: "The content you wish to show",
+            type: 'localeBlock',
+            name: "locale",
+
+        }]
 
 
 }

--- a/schemas/techInfo/techInfo.ts
+++ b/schemas/techInfo/techInfo.ts
@@ -7,29 +7,29 @@ export default {
     {
       type: 'localeString',
       name: 'header',
-      title: 'Page header',
+      title: 'Tittel (Page header)',
       description: 'The big bold letters at the top',
     },
     {
       type: 'string',
       name: 'email',
-      title: 'Concact mail',
+      title: 'Kontaktepost (Concact email)',
       description: 'The EXACT mail you want to be spammed to',
     },
     {
       type: 'localeString',
       name: 'emailDescription',
-      title: 'Email preface',
+      title: 'Epost-Forord (Email Preface)',
       description:
         'The text after the nice bold letters and before the email. The email will be below.',
     },
     {
       type: 'array',
-      title: 'Categories',
+      title: 'Kategoried (Categories)',
       name: 'categories',
-      of: [{type: 'techCategory'}],
+      of: [{ type: 'techCategory' }],
       options: {
-        modal: {type: 'dialog', width: '80%'}, //Makes the modal type a popover
+        modal: { type: 'dialog', width: '80%' }, //Makes the modal type a popover
       },
     },
   ],

--- a/schemas/translationObject/translationObject.ts
+++ b/schemas/translationObject/translationObject.ts
@@ -1,19 +1,19 @@
 export default {
-  title: 'Translation Object',
+  title: 'Oversettelsesobjekt (Translation Object)',
   name: 'translationObject',
   type: 'document',
   description: 'Text contents with translation used on the website.',
   fields: [
     {
       type: 'string',
-      title: 'Identifier',
+      title: 'Identifikator (Identifier)',
       name: 'identifier',
       description:
         'Indentifier to the content. Do not change this unless you know what you are doing.',
     },
     {
       type: 'localeString',
-      title: 'Content',
+      title: 'Innhold (Content)',
       name: 'content',
       description: 'The content with translations.',
     },


### PR DESCRIPTION
<https://github.com/Stiftelsen-Hulen/hulen_frontend/issues/55> issue 55.

Build this in local sanity, and you can see if you like the changes or not.
Have tries to translate **all** of the labels for the input fields in Sanity.

I have not translated the descriptions as well. That would be a bit much, I think...